### PR TITLE
refactor: complete semantic exception migration (NotFoundError/ExistsError)

### DIFF
--- a/src/lionherd_core/base/flow.py
+++ b/src/lionherd_core/base/flow.py
@@ -9,7 +9,7 @@ from uuid import UUID
 
 from pydantic import Field, PrivateAttr, field_validator
 
-from ..errors import NotFoundError
+from ..errors import ExistsError, NotFoundError
 from ..protocols import Serializable, implements
 from ._utils import extract_types, synchronized
 from .element import Element
@@ -150,10 +150,10 @@ class Flow(Element, Generic[E, P]):
 
     @synchronized
     def add_progression(self, progression: P) -> None:
-        """Add progression with name registration. Raises ValueError if UUID or name exists."""
+        """Add progression with name registration. Raises ExistsError if UUID or name exists."""
         # Check name uniqueness
         if progression.name and progression.name in self._progression_names:
-            raise ValueError(
+            raise ExistsError(
                 f"Progression with name '{progression.name}' already exists. Names must be unique."
             )
 

--- a/src/lionherd_core/base/graph.py
+++ b/src/lionherd_core/base/graph.py
@@ -248,16 +248,16 @@ class Graph(Element, PydapterAdaptable, PydapterAsyncAdaptable):
 
     @synchronized
     def add_edge(self, edge: Edge) -> None:
-        """Add edge to graph. Raises ValueError if head/tail missing, ExistsError if already exists.
+        """Add edge to graph. Raises NotFoundError if head/tail missing, ExistsError if already exists.
 
         Thread-safe: Uses @synchronized to ensure atomic operation across
         edges.add() and adjacency list updates. Critical for Rust port and
         Python 3.13+ nogil where GIL won't protect dict operations.
         """
         if edge.head not in self.nodes:
-            raise ValueError(f"Head node {edge.head} not in graph")
+            raise NotFoundError(f"Head node {edge.head} not in graph")
         if edge.tail not in self.nodes:
-            raise ValueError(f"Tail node {edge.tail} not in graph")
+            raise NotFoundError(f"Tail node {edge.tail} not in graph")
 
         self.edges.add(edge)
         self._out_edges[edge.head].add(edge.id)
@@ -400,7 +400,7 @@ class Graph(Element, PydapterAdaptable, PydapterAsyncAdaptable):
         end_id = self._coerce_id(end)
 
         if start_id not in self.nodes or end_id not in self.nodes:
-            raise ValueError("Start or end node not in graph")
+            raise NotFoundError("Start or end node not in graph")
 
         # BFS with parent tracking
         queue: deque[UUID] = deque([start_id])

--- a/src/lionherd_core/base/pile.py
+++ b/src/lionherd_core/base/pile.py
@@ -149,7 +149,7 @@ class Pile(Element, PydapterAdaptable, PydapterAsyncAdaptable, Generic[T]):
             # Validate that all UUIDs in order are in items
             for uid in order_list:
                 if uid not in self._items:
-                    raise ValueError(f"UUID {uid} in order not found in items")
+                    raise NotFoundError(f"UUID {uid} in order not found in items")
             # Set progression order
             self._progression = Progression(order=order_list)
 
@@ -526,7 +526,7 @@ class Pile(Element, PydapterAdaptable, PydapterAsyncAdaptable, Generic[T]):
 
         # Check if any items found
         if not filtered_items:
-            raise ValueError(f"No items of type(s) {types_to_filter} found in pile")
+            raise NotFoundError(f"No items of type(s) {types_to_filter} found in pile")
 
         # Return NEW Pile with filtered items
         new_pile = Pile(

--- a/tests/base/test_flow.py
+++ b/tests/base/test_flow.py
@@ -273,7 +273,7 @@ def test_flow_add_progression():
 
 
 def test_flow_add_progression_duplicate_name_raises():
-    """Test adding progression with duplicate name raises ValueError.
+    """Test adding progression with duplicate name raises ExistsError.
 
     Design Rationale - Name Uniqueness:
         Progression names serve as ergonomic access keys (`flow.get_progression("stage_name")`).
@@ -302,7 +302,7 @@ def test_flow_add_progression_duplicate_name_raises():
     prog2 = FlowTestProgression(name="duplicate")
 
     f.add_progression(prog1)
-    with pytest.raises(ValueError, match="Progression with name 'duplicate' already exists"):
+    with pytest.raises(ExistsError, match="Progression with name 'duplicate' already exists"):
         f.add_progression(prog2)
 
 
@@ -1088,7 +1088,7 @@ def test_flow_exception_group_collection():
         for item in batch:
             try:
                 flow.add_item(item, progression_ids="stage")
-            except ValueError as e:
+            except (ExistsError, NotFoundError) as e:
                 errors.append(e)  # Collect, don't raise immediately
 
         if errors:
@@ -1120,13 +1120,13 @@ def test_flow_exception_group_collection():
         except NotFoundError as e:
             errors.append(e)
 
-        # Try adding progression with duplicate name (raises ValueError - name uniqueness check)
+        # Try adding progression with duplicate name (raises ExistsError - name uniqueness check)
         prog1 = FlowTestProgression(name="duplicate")
         f.add_progression(prog1)
         try:
             prog2 = FlowTestProgression(name="duplicate")
             f.add_progression(prog2)
-        except ValueError as e:
+        except ExistsError as e:
             errors.append(e)
 
         # Raise ExceptionGroup if any errors
@@ -1138,10 +1138,10 @@ def test_flow_exception_group_collection():
 
     eg = exc_info.value
     assert len(eg.exceptions) == 3
-    # Mixed exception types: ExistsError, NotFoundError, ValueError
+    # Mixed exception types: ExistsError, NotFoundError, ExistsError
     assert isinstance(eg.exceptions[0], ExistsError)
     assert isinstance(eg.exceptions[1], NotFoundError)
-    assert isinstance(eg.exceptions[2], ValueError)
+    assert isinstance(eg.exceptions[2], ExistsError)
 
 
 # ==================== Async-Related Tests ====================

--- a/tests/base/test_graph.py
+++ b/tests/base/test_graph.py
@@ -594,7 +594,7 @@ class TestEdgeOperations:
             graph.add_edge(e1)
 
     def test_add_edge_missing_head_raises(self, empty_graph):
-        """Test adding edge with missing head node raises ValueError."""
+        """Test adding edge with missing head node raises NotFoundError."""
         n1 = Node(content={"value": "A"})
         n2 = Node(content={"value": "B"})
         empty_graph.add_node(n1)
@@ -602,11 +602,11 @@ class TestEdgeOperations:
         # n2 not in graph
         edge = Edge(head=n2.id, tail=n1.id)
 
-        with pytest.raises(ValueError, match=r"Head node .* not in graph"):
+        with pytest.raises(NotFoundError, match=r"Head node .* not in graph"):
             empty_graph.add_edge(edge)
 
     def test_add_edge_missing_tail_raises(self, empty_graph):
-        """Test adding edge with missing tail node raises ValueError."""
+        """Test adding edge with missing tail node raises NotFoundError."""
         n1 = Node(content={"value": "A"})
         n2 = Node(content={"value": "B"})
         empty_graph.add_node(n1)
@@ -614,7 +614,7 @@ class TestEdgeOperations:
         # n2 not in graph
         edge = Edge(head=n1.id, tail=n2.id)
 
-        with pytest.raises(ValueError, match=r"Tail node .* not in graph"):
+        with pytest.raises(NotFoundError, match=r"Tail node .* not in graph"):
             empty_graph.add_edge(edge)
 
     def test_remove_edge_basic(self, simple_graph):
@@ -1382,7 +1382,7 @@ class TestGraphAlgorithms:
         graph, _, _ = simple_graph
         fake_node = Node(content={"value": "fake"})
 
-        with pytest.raises(ValueError, match="not in graph"):
+        with pytest.raises(NotFoundError, match="not in graph"):
             await graph.find_path(
                 fake_node, graph.nodes.items[next(iter(graph.nodes.items.keys()))]
             )
@@ -1392,7 +1392,7 @@ class TestGraphAlgorithms:
         graph, (n1, _, _), _ = simple_graph
         fake_node = Node(content={"value": "fake"})
 
-        with pytest.raises(ValueError, match="not in graph"):
+        with pytest.raises(NotFoundError, match="not in graph"):
             await graph.find_path(n1, fake_node)
 
     async def test_find_path_with_conditions_all_pass(self, simple_graph):

--- a/tests/base/test_pile.py
+++ b/tests/base/test_pile.py
@@ -243,7 +243,7 @@ def test_pile_order_validation_invalid_uuid(simple_items):
     from uuid import uuid4
 
     invalid_order = [uuid4()]  # UUID not in items
-    with pytest.raises(ValueError, match=r"UUID .* not found in items"):
+    with pytest.raises(NotFoundError, match=r"UUID .* not found in items"):
         Pile(items=simple_items, order=invalid_order)
 
 
@@ -744,10 +744,10 @@ def test_filter_by_type_with_strict_validation():
 
 
 def test_filter_by_type_no_matches():
-    """Test filter_by_type raises ValueError when no matches."""
+    """Test filter_by_type raises NotFoundError when no matches."""
     pile = Pile(items=[SimpleElement(value=1)])
 
-    with pytest.raises(ValueError, match="No items of type"):
+    with pytest.raises(NotFoundError, match="No items of type"):
         pile.filter_by_type(TypedElement)
 
 


### PR DESCRIPTION
## Summary

Completes issues #129 and #131 by migrating all remaining semantic `ValueError` raises to custom exceptions (`NotFoundError`/`ExistsError`) and updating affected tests and documentation.

## Changes

### Code Changes (6 ValueError conversions)

**NotFoundError conversions** (5):
- `pile.py:152` - UUID in order not found
- `pile.py:529` - No items of type found
- `graph.py:258` - Head node not in graph
- `graph.py:260` - Tail node not in graph
- `graph.py:403` - Start/end node not in graph (find_path)

**ExistsError conversion** (1):
- `flow.py:156` - Progression name already exists

### Documentation Updates (2 docstrings)
- `graph.py:251` - add_edge docstring (ValueError → NotFoundError)
- `flow.py:153` - add_progression docstring (ValueError → ExistsError)

### Test Updates (8 tests)
- `test_pile.py`: 2 tests updated
- `test_graph.py`: 4 tests updated
- `test_flow.py`: 2 tests updated

## Testing

✅ All 264 tests pass (104 Pile + 106 Graph + 54 Flow)

## Benefits

- **Type Safety**: Catch specific exceptions instead of broad `ValueError`
- **Semantic Clarity**: Exception type indicates error category
- **Better Error Messages**: Preserve metadata (`.retryable`, `.details`, `.__cause__`)
- **Consistency**: Completes custom exception architecture from PR #117

## Notes

**docs/api/types/operable.md**: Reviewed - 4 `ValueError` occurrences are CORRECT (validation errors, not semantic errors). No changes needed.

**Remaining ValueError**: Only validation errors remain (e.g., invalid direction parameter, topological sort cycle detection) - these are intentionally kept as `ValueError`.

Closes #129
Closes #131