### PR TITLE
docs: create concurrency module overview

### DIFF
--- a/docs/api/libs/concurrency.md
+++ b/docs/api/libs/concurrency.md
@@ -164,9 +164,9 @@ async def flaky_operation():
 async with fail_after(10.0):
     result = await retry(
         flaky_operation,
-        max_attempts=3,
-        initial_delay=0.1,
-        backoff=2.0,
+        attempts=3,
+        base_delay=0.1,
+        max_delay=2.0,
         jitter=0.1,
     )
 ```
@@ -284,11 +284,11 @@ For CPU-bound work, use `ProcessPoolExecutor` instead of async concurrency.
 
 - **[AnyIO Documentation](https://anyio.readthedocs.io/)** - Underlying async abstraction
 - **[Trio Documentation](https://trio.readthedocs.io/)** - Structured concurrency inspiration
-- **[Base Module](../base/)** - Integration with Element, Node, Pile for async workflows
-- **[Notebooks](../../notebooks/)** - Practical examples and tutorials
+- **Base Module** (`../base/`) - Integration with Element, Node, Pile for async workflows
+- **Notebooks** (`../../notebooks/`) - Practical examples and tutorials
 
 ## See Also
 
-- **[libs.schema_handlers](../libs/)** - Async schema validation utilities
-- **[libs.string_handlers](../libs/)** - Async string processing utilities
-- **[protocols](../../protocols.md)** - Protocol-based composition patterns
+- **libs.schema_handlers** - Async schema validation utilities (see `../libs/schema_handlers/`)
+- **libs.string_handlers** - Async string processing utilities (see `../libs/string_handlers/`)
+- **protocols** - Protocol-based composition patterns (documentation coming soon)


### PR DESCRIPTION
## Summary

Add comprehensive overview documentation for the `libs.concurrency` module, providing a high-level guide to the 8 submodules and common usage patterns.

## Changes

**New file**: `docs/api/libs/concurrency.md` (294 lines)

**Content structure**:

1. **Module overview**: Purpose and organization
2. **8 submodule summaries**:
   - primitives (RLock, Event, Semaphore)
   - task (TaskExecutor, TaskManager)
   - cancel (CancellationToken, TimeoutManager)
   - errors (ExceptionGroup, ConcurrencyError)
   - patterns (retry, throttle, circuit breaker)
   - priority_queue (PriorityQueue)
   - resource_tracker (CapacityLimiter, ResourcePool)
   - utils (async helpers)

3. **6 common patterns** with code examples:
   - Basic parallel execution
   - Retry with exponential backoff
   - Timeout management
   - Resource limiting (CapacityLimiter)
   - Error aggregation (ExceptionGroup)
   - Task cancellation

4. **Cross-references**: Links to detailed submodule docs

## Purpose

Provides entry point for users exploring concurrency utilities, bridging high-level overview with detailed API references.

## Issues Closed

Closes #121

## Impact

Low risk - new documentation file, no code changes. Complements existing submodule docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)