### PR TITLE
fix(flow): validate referential integrity before adding progression

### DIFF
--- a/src/lionherd_core/base/flow.py
+++ b/src/lionherd_core/base/flow.py
@@ -186,7 +186,15 @@ class Flow(Element, Generic[E, P]):
                 f"Progression with name '{progression.name}' already exists. Names must be unique."
             )
 
-        # Add to progressions pile
+        # Validate referential integrity before adding to pile
+        item_ids = set(self.items.keys())
+        missing_ids = set(list(progression)) - item_ids
+        if missing_ids:
+            raise NotFoundError(
+                f"Progression '{progression.name or progression.id}' contains UUIDs not in items pile: {missing_ids}"
+            )
+
+        # Add to progressions pile (safe - validation passed)
         self.progressions.add(progression)
 
         # Register name if present


### PR DESCRIPTION
## Problem

`Flow.add_progression()` added progression to pile BEFORE validating referential integrity, which could leave the system in an inconsistent state if validation failed.

**Current Behavior** (before fix):
1. Check name uniqueness ✓
2. Add to progressions pile ⚠️ **TOO EARLY**
3. (If validation failed elsewhere, progression already in pile)

**Issue**: If progression contains UUIDs that don't exist in items pile, the progression would be added but unusable, creating inconsistent state.

## Solution

Validate referential integrity **before** adding to pile (fail fast pattern):

1. Check name uniqueness ✓
2. **Validate all UUIDs exist in items pile** ✓ **NEW**
3. Add to progressions pile ✓ (safe - validation passed)
4. Register name ✓

## Changes

### Code
- **src/lionherd_core/base/flow.py**:
  - Added referential integrity validation before `self.progressions.add()`
  - Uses same logic as `_validate_referential_integrity` model validator
  - Raises `NotFoundError` with clear message if invalid UUIDs found

### Tests
- **tests/base/test_flow.py**:
  - Added `test_flow_add_progression_validates_referential_integrity()`
  - Verifies `NotFoundError` raised for progression with invalid UUIDs
  - Verifies progression NOT added to pile (no inconsistent state)

## Testing

```bash
uv run pytest tests/base/test_flow.py -v
# 61 tests passed (60 existing + 1 new)
```

## Consistency

This fix makes `add_progression()` consistent with `__init__`:
- **__init__**: Uses `@model_validator` to validate referential integrity (PR #162)
- **add_progression()**: Now validates before adding (this PR)

Both methods enforce the same constraint: all progression UUIDs must exist in items pile.

## Related

- Closes #164
- Related to PR #162: Added `@model_validator` for `__init__` validation

## Priority

P1 for v1.0.0 - Critical for API consistency and preventing inconsistent state.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)