### PR TITLE
feat(api): expand top-level exports for simpler imports

### DIFF
--- a/src/lionherd_core/__init__.py
+++ b/src/lionherd_core/__init__.py
@@ -22,11 +22,34 @@ from .base import (
     Pile,
     Progression,
 )
-from .errors import LionherdError
+from .errors import (
+    ConfigurationError,
+    ConnectionError,
+    ExecutionError,
+    ExistsError,
+    LionherdError,
+    NotFoundError,
+    TimeoutError,
+    ValidationError,
+)
 from .libs import (
     concurrency as concurrency,
     schema_handlers as schema_handlers,
     string_handlers as string_handlers,
+)
+from .protocols import (
+    Adaptable,
+    AdapterRegisterable,
+    Allowable,
+    AsyncAdaptable,
+    AsyncAdapterRegisterable,
+    Containable,
+    Deserializable,
+    Hashable,
+    Invocable,
+    Observable,
+    Serializable,
+    implements,
 )
 from .types import (
     CommonMeta,
@@ -50,9 +73,22 @@ from .types import (
 )
 
 __all__ = (
+    # Protocols
+    "Adaptable",
+    "AdapterRegisterable",
+    "Allowable",
+    "AsyncAdaptable",
+    "AsyncAdapterRegisterable",
+    # Base structures
     "Broadcaster",
+    # Types
     "CommonMeta",
+    # Errors
+    "ConfigurationError",
+    "ConnectionError",
+    "Containable",
     "DataClass",
+    "Deserializable",
     "Edge",
     "EdgeCondition",
     "Element",
@@ -61,9 +97,13 @@ __all__ = (
     "EventBus",
     "EventStatus",
     "Execution",
+    "ExecutionError",
+    "ExistsError",
     "Flow",
     "Graph",
+    "Hashable",
     "HashableModel",
+    "Invocable",
     "LionherdError",
     "MaybeSentinel",
     "MaybeUndefined",
@@ -71,16 +111,23 @@ __all__ = (
     "Meta",
     "ModelConfig",
     "Node",
+    "NotFoundError",
+    "Observable",
     "Operable",
     "Params",
     "Pile",
     "Progression",
+    "Serializable",
     "Spec",
+    "TimeoutError",
     "Undefined",
     "UndefinedType",
     "Unset",
     "UnsetType",
+    "ValidationError",
+    # Namespaces
     "concurrency",
+    "implements",
     "is_sentinel",
     "ln",
     "lndl",


### PR DESCRIPTION
## Problem

Users need to import from nested paths which is verbose and inconsistent:

```python
# Current (mixed levels)
from lionherd_core.base import Node, Graph
from lionherd_core.protocols import Observable, Serializable
from lionherd_core.errors import NotFoundError, ExistsError
```

This creates:
- **Discovery friction**: Users don't know which level exports live at
- **Verbose imports**: Multiple import lines for common patterns
- **Inconsistent experience**: Some at top level, some nested

## Solution

Export nearly everything at top level, use namespace imports only for `ln`, `lndl`, and `libs/*`:

```python
# Proposed (consistent)
from lionherd_core import (
    # Base structures
    Node, Graph, Flow, Pile,
    
    # Protocols  
    Observable, Serializable, Adaptable, implements,
    
    # Errors
    NotFoundError, ExistsError, ValidationError,
    
    # Namespaces (for clarity)
    ln,           # ln.alcall()
    lndl,         # lndl.parse_lndl_fuzzy()
    concurrency,  # concurrency.sleep()
)
```

## Benefits

1. **Consistency**: Most things at top level, namespaces for modules
2. **Convenience**: Single import line for common use cases
3. **Discovery**: IDE autocomplete shows all exports immediately
4. **Readability**: `from lionherd_core import Node` clearer than nested paths

## Changes

### Added Exports

**Protocols** (10 new):
- `Observable`, `Serializable`, `Adaptable`, `AdapterRegisterable`
- `AsyncAdaptable`, `AsyncAdapterRegisterable`
- `Deserializable`, `Containable`, `Allowable`, `Invocable`, `Hashable`
- `implements` decorator

**Errors** (7 new):
- `NotFoundError`, `ExistsError`, `ValidationError`
- `ConfigurationError`, `ConnectionError`, `ExecutionError`, `TimeoutError`
- (LionherdError already exported)

### Code Changes

- **src/lionherd_core/__init__.py**:
  - Added protocol imports from `.protocols`
  - Added error imports from `.errors` (expanded from just LionherdError)
  - Updated `__all__` tuple with new exports (auto-sorted by ruff)
  - Organized with category comments for clarity

## Testing

```bash
# Verify imports work
uv run python -c "from lionherd_core import Observable, NotFoundError, implements"
# ✓ All imports successful

# Run test suite
uv run pytest tests/ -q
# ✓ All tests pass (no regressions)

# Pre-commit checks
uv run pre-commit run --files src/lionherd_core/__init__.py
# ✓ All checks pass
```

## Migration Impact

**Backwards Compatible**: All existing imports still work (additive change only)

```python
# Old style (still works)
from lionherd_core.protocols import Observable

# New style (now also works)
from lionherd_core import Observable
```

## Related

- Closes #148
- Phase 1 complete: Export all protocols, errors at top level
- Phase 2 (future): Update documentation with recommended import style

## Priority

**P1** for v1.0.0 - Improves API consistency and UX before stable release

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)